### PR TITLE
Use SPM utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking
 - Rename project to xcodeproj by @pepibumur.
-- Drop Carthage and CocoaPods support by @pepibumur https://github.com/xcbuddy/xcodeproj/pull/8.
+- Drop Carthage and CocoaPods support https://github.com/xcbuddy/xcodeproj/pull/8 by @pepibumur.
+- Use Basic AbsolutePath, RelativePath and Process extensions https://github.com/xcbuddy/xcodeproj/pull/1 by @pepibumur.
 
 ### Added
 - Danger check that reports Swiftlint results https://github.com/xcodeswift/xcproj/pull/257 by @pepibumur.

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,30 +11,12 @@
         }
       },
       {
-        "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit.git",
+        "package": "SwiftPM",
+        "repositoryURL": "https://github.com/apple/swift-package-manager",
         "state": {
           "branch": null,
-          "revision": "fa81fa9e3a9f59645159c4ea45c0c46ee6558f71",
-          "version": "0.9.1"
-        }
-      },
-      {
-        "package": "ShellOut",
-        "repositoryURL": "https://github.com/JohnSundell/ShellOut.git",
-        "state": {
-          "branch": null,
-          "revision": "f1c253a34a40df4bfd268b09fdb101b059f6d52d",
-          "version": "2.1.0"
-        }
-      },
-      {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "e34d5687e1e9d865e3527dd58bc2f7464ef6d936",
-          "version": "0.8.0"
+          "revision": "63a01220e93271dc3bf204b9e13dd1aeb2beefee",
+          "version": "0.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,14 +7,13 @@ let package = Package(
         .library(name: "xcodeproj", targets: ["xcodeproj"]),
         ],
     dependencies: [
-        .package(url: "https://github.com/kylef/PathKit.git", .upToNextMajor(from: "0.9.1")),
         .package(url: "https://github.com/tadija/AEXML.git", .upToNextMajor(from: "4.3.0")),
-        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0")
+        .package(url: "https://github.com/apple/swift-package-manager", .upToNextMajor(from: "0.2.0")),
         ],
     targets: [
         .target(name: "xcodeproj",
-                dependencies: ["PathKit", "AEXML"]),
+                dependencies: ["Utility", "AEXML"]),
         .testTarget(name: "xcodeprojTests", dependencies: ["xcodeproj"]),
-        .testTarget(name: "xcodeprojIntegrationTests", dependencies: ["xcodeproj", "PathKit", "ShellOut"]),
+        .testTarget(name: "xcodeprojIntegrationTests", dependencies: ["xcodeproj"]),
     ]
 )

--- a/Sources/xcodeproj/PBXFileReference.swift
+++ b/Sources/xcodeproj/PBXFileReference.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 ///  A PBXFileReference is used to track every external file referenced by
 ///  the project: source files, resource files, libraries, generated application files, and so on.
@@ -181,7 +181,7 @@ extension PBXFileReference {
     ///
     /// - Parameter path: path whose file type will be returned.
     /// - Returns: file type (if supported).
-    public static func fileType(path: Path) -> String? {
+    public static func fileType(path: RelativePath) -> String? {
         return path.extension.flatMap({fileTypeHash[$0]})
     }
     

--- a/Sources/xcodeproj/PBXFileReference.swift
+++ b/Sources/xcodeproj/PBXFileReference.swift
@@ -181,7 +181,7 @@ extension PBXFileReference {
     ///
     /// - Parameter path: path whose file type will be returned.
     /// - Returns: file type (if supported).
-    public static func fileType(path: RelativePath) -> String? {
+    public static func fileType(path: AbsolutePath) -> String? {
         return path.extension.flatMap({fileTypeHash[$0]})
     }
     

--- a/Sources/xcodeproj/PBXHeadersBuildPhase.swift
+++ b/Sources/xcodeproj/PBXHeadersBuildPhase.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 /// This is the element for the framework headers build phase.
 final public class PBXHeadersBuildPhase: PBXBuildPhase {
@@ -17,7 +17,7 @@ extension PBXHeadersBuildPhase {
     ///
     /// - Parameter path: path to be checked.
     /// - Returns: true if the path points to a header file.
-    static func isHeader(path: Path) -> Bool {
+    static func isHeader(path: RelativePath) -> Bool {
         return path.extension.flatMap({isHeader(fileExtension: $0)}) ?? false
     }
     

--- a/Sources/xcodeproj/PBXProj+Helpers.swift
+++ b/Sources/xcodeproj/PBXProj+Helpers.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 // MARK: - PBXProj Extension (Public)
 
@@ -33,13 +33,13 @@ extension PBXProj {
     ///
     /// - Parameters:
     ///   - path: path to .xcodeproj directory.
-    func updateProjectName(path: Path) {
-        guard path.parent().extension == "xcodeproj" else {
+    func updateProjectName(path: AbsolutePath) {
+        guard path.parentDirectory.extension == "xcodeproj" else {
             return
         }
-        let projectName = path.parent().lastComponentWithoutExtension
+        let projectName = path.parentDirectory.components.last?.split(separator: ".").first
         let rootProject = objects.projects.getReference(rootObject)
-        rootProject?.name = projectName
+        rootProject?.name = projectName.map(String.init) ?? ""
     }
 
 }
@@ -48,7 +48,7 @@ extension PBXProj {
 
 extension PBXProj: Writable {
 
-    public func write(path: Path, override: Bool) throws {
+    public func write(path: AbsolutePath, override: Bool) throws {
         let encoder = PBXProjEncoder()
         let output = encoder.encode(proj: self)
         if override && path.exists {

--- a/Sources/xcodeproj/PBXProj.swift
+++ b/Sources/xcodeproj/PBXProj.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 /// Represents a .pbxproj file
 final public class PBXProj: Decodable {

--- a/Sources/xcodeproj/PBXProjError.swift
+++ b/Sources/xcodeproj/PBXProjError.swift
@@ -1,14 +1,14 @@
 import Foundation
-import PathKit
+import Basic
 
 // MARK: - PBXProj Error
 
 enum PBXProjError: Error, CustomStringConvertible {
-    case notFound(path: Path)
+    case notFound(path: AbsolutePath)
     var description: String {
         switch self {
         case .notFound(let path):
-            return ".pbxproj not found at path \(path)"
+            return ".pbxproj not found at path \(path.asString)"
         }
     }
 }

--- a/Sources/xcodeproj/PBXProjObjects+Helpers.swift
+++ b/Sources/xcodeproj/PBXProjObjects+Helpers.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 // MARK: - PBXProj.Objects Extension (Public)
 
@@ -208,43 +208,16 @@ public struct GroupAddingOptions: OptionSet {
 }
 
 public enum XCodeProjEditingError: Error, CustomStringConvertible {
-    case fileNotExists(path: Path)
+    case fileNotExists(path: AbsolutePath)
     case groupNotFound(group: PBXGroup)
 
     public var description: String {
         switch self {
         case .fileNotExists(let path):
-            return "\(path) does not exist"
+            return "\(path.asString) does not exist"
         case .groupNotFound(let group):
             return "Group not found in project: \(group)"
         }
-    }
-}
-
-extension Path {
-    fileprivate init(_ string: String, relativeTo relativePath: Path) {
-        var path = Path(string)
-        if !path.isAbsolute {
-            path = (relativePath + path).absolute()
-        }
-        self.init(path.string)
-    }
-
-    public func relativeTo(_ relativePath: Path) -> Path {
-        let components = self.absolute().components
-        let relativePathComponents = relativePath.absolute().components
-
-        var commonPathComponents = [String]()
-        for component in components {
-            guard relativePathComponents.count > commonPathComponents.count else { break }
-            guard relativePathComponents[commonPathComponents.count] == component else { break }
-            commonPathComponents.append(component)
-        }
-
-        let relative = Array(repeating: "..", count: (relativePathComponents.count - commonPathComponents.count))
-        let suffix = components.suffix(components.count - commonPathComponents.count)
-        let path = Path(components: relative + suffix)
-        return path
     }
 }
 

--- a/Sources/xcodeproj/Path+Extras.swift
+++ b/Sources/xcodeproj/Path+Extras.swift
@@ -57,6 +57,14 @@ extension AbsolutePath {
         try FileManager.default.createDirectory(atPath: self.asString, withIntermediateDirectories: withIntermediateDirectories, attributes: nil)
     }
     
+    /// Copies a file to another path.
+    ///
+    /// - Parameter to: path the file/directory will be copied  to.
+    func copy(_ to: AbsolutePath) throws {
+        try FileManager.default.copyItem(atPath: self.asString,
+                                     toPath: to.asString)
+    }
+    
     /// Finds files and directories using the given glob pattern.
     ///
     /// - Parameter pattern: glob pattern.

--- a/Sources/xcodeproj/Path+Extras.swift
+++ b/Sources/xcodeproj/Path+Extras.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Basic
+
+// MARK: - AbsolutePath extras.
+
+extension AbsolutePath {
+
+    /// Returns true if a file exists at the given path.
+    var exists: Bool {
+        return FileManager.default.fileExists(atPath: self.asString)
+    }
+    
+    /// Returns last path component without the extension.
+    var lastComponentWithoutExtension: String {
+        return self.components.last?.split(separator: ".").first.map(String.init) ?? ""
+    }
+    
+    /// Deletes the file at the given path.
+    ///
+    /// - Throws: an error if the deletion fails.
+    func delete() throws {
+        try FileManager.default.removeItem(atPath: self.asString)
+    }
+    
+    /// Writes the string atomically into a file at the given path.
+    ///
+    /// - Parameter content: content to be written.
+    /// - Throws: an error if the writing fails.
+    func write(_ content: String) throws {
+        try content.write(toFile: self.asString, atomically: true, encoding: .utf8)
+    }
+    
+    /// Reads the content (string) at the given path.
+    ///
+    /// - Returns: file content.
+    /// - Throws: an error if the content cannot be read.
+    func read() throws -> String {
+        return try String.init(contentsOf: URL(fileURLWithPath: self.asString))
+    }
+}

--- a/Sources/xcodeproj/Path+Extras.swift
+++ b/Sources/xcodeproj/Path+Extras.swift
@@ -3,11 +3,23 @@ import Basic
 
 // MARK: - AbsolutePath extras.
 
-extension AbsolutePath {
+let systemGlob = Darwin.glob
 
+extension AbsolutePath {
+    
+    /// Returns the URL that points to the file path.
+    var url: URL {
+        return URL(fileURLWithPath: self.asString)
+    }
+    
     /// Returns true if a file exists at the given path.
     var exists: Bool {
         return FileManager.default.fileExists(atPath: self.asString)
+    }
+    
+    /// Returns the last path component.
+    var lastComponent: String {
+        return self.components.last ?? ""
     }
     
     /// Returns last path component without the extension.
@@ -36,5 +48,37 @@ extension AbsolutePath {
     /// - Throws: an error if the content cannot be read.
     func read() throws -> String {
         return try String.init(contentsOf: URL(fileURLWithPath: self.asString))
+    }
+    
+    /// Creates a directory
+    ///
+    /// - Throws: an errof if the directory cannot be created.
+    func mkpath(withIntermediateDirectories: Bool = true) throws {
+        try FileManager.default.createDirectory(atPath: self.asString, withIntermediateDirectories: withIntermediateDirectories, attributes: nil)
+    }
+    
+    /// Finds files and directories using the given glob pattern.
+    ///
+    /// - Parameter pattern: glob pattern.
+    /// - Returns: found directories and files.
+    public func glob(_ pattern: String) -> [AbsolutePath] {
+        var gt = glob_t()
+        let cPattern = strdup(appending(RelativePath(pattern)).asString)
+        defer {
+            globfree(&gt)
+            free(cPattern)
+        }
+        
+        let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
+        if systemGlob(cPattern, flags, nil, &gt) == 0 {
+            let matchc = gt.gl_matchc
+            return (0 ..< Int(matchc)).compactMap { index in
+                if let path = String(validatingUTF8: gt.gl_pathv[index]!) {
+                    return AbsolutePath(path)
+                }
+                return nil
+            }
+        }
+        return []
     }
 }

--- a/Sources/xcodeproj/Writable.swift
+++ b/Sources/xcodeproj/Writable.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 /// Protocol that defines how an entity can be writed into disk
 public protocol Writable {
@@ -9,7 +9,7 @@ public protocol Writable {
     /// - Parameter path: The path to write to
     /// - Parameter override: True if the content should be overriden if it already exists.
     /// - Throws: writing error if something goes wrong.
-    func write(path: Path, override: Bool) throws
+    func write(path: AbsolutePath, override: Bool) throws
 
     /// Writes the object that conforms the protocol.
     ///
@@ -22,7 +22,7 @@ public protocol Writable {
 extension Writable {
 
     public func write(pathString: String, override: Bool) throws {
-        let path = Path(pathString)
+        let path = AbsolutePath(pathString)
         try write(path: path, override: override)
     }
 }

--- a/Sources/xcodeproj/XCBreakpointList.swift
+++ b/Sources/xcodeproj/XCBreakpointList.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 import AEXML
 
 // swiftlint:disable:next type_body_length
@@ -297,7 +297,7 @@ final public class XCBreakpointList {
     ///
     /// - Parameters:
     ///   - path: breakpoints path.
-    public init(path: Path) throws {
+    public init(path: AbsolutePath) throws {
         if !path.exists {
             throw XCBreakpointListError.notFound(path: path)
         }
@@ -330,7 +330,7 @@ final public class XCBreakpointList {
 
 extension XCBreakpointList: Writable {
     
-    public func write(path: Path, override: Bool) throws {
+    public func write(path: AbsolutePath, override: Bool) throws {
         let document = AEXMLDocument()
         var schemeAttributes: [String: String] = [:]
         schemeAttributes["type"] = type
@@ -356,13 +356,13 @@ extension XCBreakpointList: Writable {
 /// - notFound: returned when the Breakpoints_v2.xcbkptlist cannot be found.
 /// - missing: returned when there's a property missing in the Breakpoints_v2.xcbkptlist.
 public enum XCBreakpointListError: Error, CustomStringConvertible {
-    case notFound(path: Path)
+    case notFound(path: AbsolutePath)
     case missing(property: String)
     
     public var description: String {
         switch self {
         case .notFound(let path):
-            return "Breakpoints_v2.xcbkptlist couldn't be found at path \(path)"
+            return "Breakpoints_v2.xcbkptlist couldn't be found at path \(path.asString)"
         case .missing(let property):
             return "Property \(property) missing"
         }

--- a/Sources/xcodeproj/XCConfig.swift
+++ b/Sources/xcodeproj/XCConfig.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Basic
 
-public typealias XCConfigInclude = (include: AbsolutePath, config: XCConfig)
+public typealias XCConfigInclude = (include: RelativePath, config: XCConfig)
 
 /// .xcconfig configuration file.
 final public class XCConfig {
@@ -52,7 +52,7 @@ final class XCConfigParser {
     /// - Parameter path: path of the config file that the line belongs to.
     /// - Parameter projectPath: path where the .xcodeproj is, for resolving project-relative includes.
     /// - Returns: function that parses the line.
-    static func configFrom(path: AbsolutePath, projectPath: AbsolutePath?) -> (String) -> (include: AbsolutePath, config: XCConfig)? {
+    static func configFrom(path: AbsolutePath, projectPath: AbsolutePath?) -> (String) -> (include: RelativePath, config: XCConfig)? {
         return { line in
             return includeRegex.matches(in: line,
                                                  options: NSRegularExpression.MatchingOptions(rawValue: 0),
@@ -65,20 +65,16 @@ final class XCConfigParser {
                     return nil
                 }
                 .compactMap { pathString in
-                    let includePath: Path = Path(pathString)
+                    let includePath: RelativePath = RelativePath(pathString)
                     var config: XCConfig?
-                    if includePath.isRelative {
-                        do {
-                            // first try to load the included xcconfig relative to the current xcconfig
-                            config = try XCConfig(path: path.parent() + includePath, projectPath: projectPath)
-                        } catch (XCConfigError.notFound(_)) where projectPath != nil {
-                            // if that fails, try to load the included xcconfig relative to the project
-                            config = try? XCConfig(path: projectPath!.parent() + includePath, projectPath: projectPath)
-                        } catch {
-                            config = nil
-                        }
-                    } else {
-                        config = try? XCConfig(path: includePath, projectPath: projectPath)
+                    do {
+                        // first try to load the included xcconfig relative to the current xcconfig
+                        config = try XCConfig(path: path.parentDirectory.appending(includePath), projectPath: projectPath)
+                    } catch (XCConfigError.notFound(_)) where projectPath != nil {
+                        // if that fails, try to load the included xcconfig relative to the project
+                        config = try? XCConfig(path: projectPath!.parentDirectory.appending(includePath), projectPath: projectPath)
+                    } catch {
+                        config = nil
                     }
                     return config.map { (includePath, $0) }
                 }
@@ -167,7 +163,7 @@ extension XCConfig: Writable {
     private func writeIncludes() -> String {
         var content = ""
         includes.forEach { (include) in
-            content.append("#include \"\(include.0.string)\"\n")
+            content.append("#include \"\(include.0.asString)\"\n")
         }
         content.append("\n")
         return content

--- a/Sources/xcodeproj/XCConfig.swift
+++ b/Sources/xcodeproj/XCConfig.swift
@@ -1,7 +1,7 @@
 import Foundation
-import PathKit
+import Basic
 
-public typealias XCConfigInclude = (include: Path, config: XCConfig)
+public typealias XCConfigInclude = (include: AbsolutePath, config: XCConfig)
 
 /// .xcconfig configuration file.
 final public class XCConfig {
@@ -31,7 +31,7 @@ final public class XCConfig {
     /// - Parameter path: path where the .xcconfig file is.
     /// - Parameter projectPath: path where the .xcodeproj is, for resolving project-relative includes.
     /// - Throws: an error if the config file cannot be found or it has an invalid format.
-    public init(path: Path, projectPath: Path? = nil) throws {
+    public init(path: AbsolutePath, projectPath: AbsolutePath? = nil) throws {
         if !path.exists { throw XCConfigError.notFound(path: path) }
         let fileLines = try path.read().components(separatedBy: "\n")
         self.includes = fileLines
@@ -52,7 +52,7 @@ final class XCConfigParser {
     /// - Parameter path: path of the config file that the line belongs to.
     /// - Parameter projectPath: path where the .xcodeproj is, for resolving project-relative includes.
     /// - Returns: function that parses the line.
-    static func configFrom(path: Path, projectPath: Path?) -> (String) -> (include: Path, config: XCConfig)? {
+    static func configFrom(path: AbsolutePath, projectPath: AbsolutePath?) -> (String) -> (include: AbsolutePath, config: XCConfig)? {
         return { line in
             return includeRegex.matches(in: line,
                                                  options: NSRegularExpression.MatchingOptions(rawValue: 0),
@@ -153,7 +153,7 @@ extension XCConfig {
 
 extension XCConfig: Writable {
 
-    public func write(path: Path, override: Bool) throws {
+    public func write(path: AbsolutePath, override: Bool) throws {
         var content = ""
         content.append(writeIncludes())
         content.append("\n")
@@ -209,11 +209,11 @@ extension Array where Element == XCConfig {
 ///
 /// - notFound: returned when the configuration file couldn't be found.
 public enum XCConfigError: Error, CustomStringConvertible {
-    case notFound(path: Path)
+    case notFound(path: AbsolutePath)
     public var description: String {
         switch self {
         case .notFound(let path):
-            return ".xcconfig file not found at \(path)"
+            return ".xcconfig file not found at \(path.asString)"
         }
     }
 }

--- a/Sources/xcodeproj/XCScheme.swift
+++ b/Sources/xcodeproj/XCScheme.swift
@@ -875,7 +875,7 @@ final public class XCScheme {
 
 extension XCScheme: Writable {
 
-    public func write(path: Path, override: Bool) throws {
+    public func write(path: AbsolutePath, override: Bool) throws {
         let document = AEXMLDocument()
         var schemeAttributes: [String: String] = [:]
         schemeAttributes["LastUpgradeVersion"] = lastUpgradeVersion
@@ -915,13 +915,13 @@ extension XCScheme: Writable {
 /// - notFound: returned when the .xcscheme cannot be found.
 /// - missing: returned when there's a property missing in the .xcscheme.
 public enum XCSchemeError: Error, CustomStringConvertible {
-    case notFound(path: Path)
+    case notFound(path: AbsolutePath)
     case missing(property: String)
 
     public var description: String {
         switch self {
         case .notFound(let path):
-            return ".xcscheme couldn't be found at path \(path)"
+            return ".xcscheme couldn't be found at path \(path.asString)"
         case .missing(let property):
             return "Property \(property) missing"
         }

--- a/Sources/xcodeproj/XCScheme.swift
+++ b/Sources/xcodeproj/XCScheme.swift
@@ -1,6 +1,6 @@
 import Foundation
-import PathKit
-import PathKit
+import Basic
+import Basic
 import AEXML
 
 // swiftlint:disable:next type_body_length
@@ -832,7 +832,7 @@ final public class XCScheme {
     ///
     /// - Parameters:
     ///   - path: scheme path.
-    public init(path: Path) throws {
+    public init(path: AbsolutePath) throws {
         if !path.exists {
             throw XCSchemeError.notFound(path: path)
         }

--- a/Sources/xcodeproj/XCSharedData.swift
+++ b/Sources/xcodeproj/XCSharedData.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 final public class XCSharedData {
 
@@ -26,7 +26,7 @@ final public class XCSharedData {
     /// Initializes the XCSharedData reading the content from the disk.
     ///
     /// - Parameter path: path where the .xcshareddata is.
-    public init(path: Path) throws {
+    public init(path: AbsolutePath) throws {
         if !path.exists {
             throw XCSharedDataError.notFound(path: path)
         }
@@ -41,12 +41,12 @@ final public class XCSharedData {
 ///
 /// - notFound: the share data hasn't been found.
 public enum XCSharedDataError: Error, CustomStringConvertible {
-    case notFound(path: Path)
+    case notFound(path: AbsolutePath)
 
     public var description: String {
         switch self {
         case .notFound(let path):
-            return "xcshareddata not found at path \(path)"
+            return "xcshareddata not found at path \(path.asString)"
         }
     }
 

--- a/Sources/xcodeproj/XCSharedData.swift
+++ b/Sources/xcodeproj/XCSharedData.swift
@@ -32,7 +32,7 @@ final public class XCSharedData {
         }
         self.schemes = path.glob("xcschemes/*.xcscheme")
             .compactMap { try? XCScheme(path: $0) }
-        self.breakpoints = try? XCBreakpointList(path: path + "xcdebugger/Breakpoints_v2.xcbkptlist")
+        self.breakpoints = try? XCBreakpointList(path: path.appending(RelativePath("xcdebugger/Breakpoints_v2.xcbkptlist")))
     }
 
 }

--- a/Sources/xcodeproj/XCVersionGroup.swift
+++ b/Sources/xcodeproj/XCVersionGroup.swift
@@ -78,7 +78,7 @@ final public class XCVersionGroup: PBXGroup {
         if let currentVersion = currentVersion {
             dictionary["currentVersion"] = .string(CommentedString(currentVersion, comment: proj.objects.fileName(fileReference: currentVersion)))
         }
-        return (key: CommentedString(reference, comment: path.flatMap({AbsolutePath($0)})?.lastComponent),
+        return (key: CommentedString(reference, comment: path?.split(separator: "/").last.map(String.init)),
                 value: .dictionary(dictionary))
     }
 }

--- a/Sources/xcodeproj/XCVersionGroup.swift
+++ b/Sources/xcodeproj/XCVersionGroup.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 /// Group that contains multiple files references to the different versions of a resource.
 /// Used to contain the different versions of a xcdatamodel

--- a/Sources/xcodeproj/XCVersionGroup.swift
+++ b/Sources/xcodeproj/XCVersionGroup.swift
@@ -78,7 +78,7 @@ final public class XCVersionGroup: PBXGroup {
         if let currentVersion = currentVersion {
             dictionary["currentVersion"] = .string(CommentedString(currentVersion, comment: proj.objects.fileName(fileReference: currentVersion)))
         }
-        return (key: CommentedString(reference, comment: path.flatMap({Path($0)})?.lastComponent),
+        return (key: CommentedString(reference, comment: path.flatMap({AbsolutePath($0)})?.lastComponent),
                 value: .dictionary(dictionary))
     }
 }

--- a/Sources/xcodeproj/XCWorkspace.swift
+++ b/Sources/xcodeproj/XCWorkspace.swift
@@ -56,7 +56,7 @@ final public class XCWorkspace {
 extension XCWorkspace: Writable {
 
     public func write(path: AbsolutePath, override: Bool = true) throws {
-        let dataPath = path + "contents.xcworkspacedata"
+        let dataPath = path.appending(component: "contents.xcworkspacedata")
         if override && dataPath.exists {
             try dataPath.delete()
         }
@@ -81,15 +81,15 @@ extension XCWorkspace: Equatable {
 /// - notFound: the project cannot be found.
 public enum XCWorkspaceError: Error, CustomStringConvertible {
 
-    case notFound(path: Path)
-    case xcworkspaceDataNotFound(path: Path)
+    case notFound(path: AbsolutePath)
+    case xcworkspaceDataNotFound(path: AbsolutePath)
 
     public var description: String {
         switch self {
         case .notFound(let path):
-            return "The project cannot be found at \(path)"
+            return "The project cannot be found at \(path.asString)"
         case .xcworkspaceDataNotFound(let path):
-            return "Workspace doesn't contain a .xcworkspacedata file at \(path)"
+            return "Workspace doesn't contain a .xcworkspacedata file at \(path.asString)"
 
         }
     }

--- a/Sources/xcodeproj/XCWorkspace.swift
+++ b/Sources/xcodeproj/XCWorkspace.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 /// Model that represents a Xcode workspace.
 final public class XCWorkspace {
@@ -15,7 +15,7 @@ final public class XCWorkspace {
     ///
     /// - Parameter path: .xcworkspace path.
     /// - Throws: throws an error if the workspace cannot be initialized.
-    public convenience init(path: Path) throws {
+    public convenience init(path: AbsolutePath) throws {
         if !path.exists {
             throw XCWorkspaceError.notFound(path: path)
         }
@@ -38,7 +38,7 @@ final public class XCWorkspace {
     /// - Parameter pathString: path string.
     /// - Throws: throws an error if the initialization fails.
     public convenience init(pathString: String) throws {
-        try self.init(path: Path(pathString))
+        try self.init(path: AbsolutePath(pathString))
     }
 
     /// Initializes the workspace with its properties.
@@ -55,7 +55,7 @@ final public class XCWorkspace {
 
 extension XCWorkspace: Writable {
 
-    public func write(path: Path, override: Bool = true) throws {
+    public func write(path: AbsolutePath, override: Bool = true) throws {
         let dataPath = path + "contents.xcworkspacedata"
         if override && dataPath.exists {
             try dataPath.delete()

--- a/Sources/xcodeproj/XCWorkspaceData.swift
+++ b/Sources/xcodeproj/XCWorkspaceData.swift
@@ -26,7 +26,7 @@ extension XCWorkspaceData: Writable {
     ///
     /// - Parameter path: .xcworkspace path.
     /// - Throws: throws an error if the workspace cannot be initialized.
-    public convenience init(path: Path) throws {
+    public convenience init(path: AbsolutePath) throws {
         if !path.exists {
             throw XCWorkspaceDataError.notFound(path: path)
         }
@@ -42,7 +42,7 @@ extension XCWorkspaceData: Writable {
 
     // MARK: - <Writable>
 
-    public func write(path: Path, override: Bool = true) throws {
+    public func write(path: AbsolutePath, override: Bool = true) throws {
         let document = AEXMLDocument()
         let workspace = document.addChild(name: "Workspace", value: nil, attributes: ["version": "1.0"])
         _ = children
@@ -63,12 +63,12 @@ extension XCWorkspaceData: Writable {
 /// - notFound: returned when the .xcworkspacedata cannot be found.
 public enum XCWorkspaceDataError: Error, CustomStringConvertible {
 
-    case notFound(path: Path)
+    case notFound(path: AbsolutePath)
 
     public var description: String {
         switch self {
         case .notFound(let path):
-            return "Workspace not found at \(path)"
+            return "Workspace not found at \(path.asString)"
         }
     }
 

--- a/Sources/xcodeproj/XCWorkspaceData.swift
+++ b/Sources/xcodeproj/XCWorkspaceData.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 import AEXML
 
 final public class XCWorkspaceData {

--- a/Sources/xcodeproj/XcodeProj.swift
+++ b/Sources/xcodeproj/XcodeProj.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 
 #if os(Linux)
 import Glibc

--- a/Sources/xcodeproj/XcodeProj.swift
+++ b/Sources/xcodeproj/XcodeProj.swift
@@ -22,7 +22,7 @@ final public class XcodeProj {
 
     // MARK: - Init
 
-    public init(path: Path) throws {
+    public init(path: AbsolutePath) throws {
         if !path.exists { throw XCodeProjError.notFound(path: path) }
         let pbxprojPaths = path.glob("*.pbxproj")
         if pbxprojPaths.count == 0 {
@@ -38,12 +38,12 @@ final public class XcodeProj {
         } else {
             workspace = try XCWorkspace(path: xcworkspacePaths.first!)
         }
-        let sharedDataPath = path + Path("xcshareddata")
+        let sharedDataPath = path.appending(component: "xcshareddata")
         self.sharedData = try? XCSharedData(path: sharedDataPath)
     }
     
     public convenience init(pathString: String) throws {
-        try self.init(path: Path(pathString))
+        try self.init(path: AbsolutePath(pathString))
     }
 
     /// Initializes the XCodeProj
@@ -68,7 +68,7 @@ extension XcodeProj: Writable {
     /// - Parameter path: path to `.xcodeproj` file.
     /// - Parameter override: if project should be overridden. Default is true.
     ///   If false will throw error if project already exists at the given path.
-    public func write(path: Path, override: Bool = true) throws {
+    public func write(path: AbsolutePath, override: Bool = true) throws {
         try path.mkpath()
         try writeWorkspace(path: path, override: override)
         try writePBXProj(path: path, override: override)
@@ -80,8 +80,8 @@ extension XcodeProj: Writable {
     ///
     /// - Parameter path: `.xcodeproj` file path
     /// - Returns: worspace file path relative to the given path.
-    public static func workspacePath(_ path: Path) -> Path {
-        return path + "project.xcworkspace"
+    public static func workspacePath(_ path: AbsolutePath) -> AbsolutePath {
+        return path.appending(component: "project.xcworkspace")
     }
 
     /// Writes workspace to the given path.
@@ -89,7 +89,7 @@ extension XcodeProj: Writable {
     /// - Parameter path: path to `.xcodeproj` file.
     /// - Parameter override: if workspace should be overridden. Default is true.
     ///   If false will throw error if workspace already exists at the given path.
-    public func writeWorkspace(path: Path, override: Bool = true) throws {
+    public func writeWorkspace(path: AbsolutePath, override: Bool = true) throws {
         try workspace.write(path: XcodeProj.workspacePath(path), override: override)
     }
 
@@ -97,8 +97,8 @@ extension XcodeProj: Writable {
     ///
     /// - Parameter path: `.xcodeproj` file path
     /// - Returns: project file path relative to the given path.
-    public static func pbxprojPath(_ path: Path) -> Path {
-        return path + "project.pbxproj"
+    public static func pbxprojPath(_ path: AbsolutePath) -> AbsolutePath {
+        return path.appending(component: "project.pbxproj")
     }
 
     /// Writes project to the given path.
@@ -106,7 +106,7 @@ extension XcodeProj: Writable {
     /// - Parameter path: path to `.xcodeproj` file.
     /// - Parameter override: if project should be overridden. Default is true.
     ///   If false will throw error if project already exists at the given path.
-    public func writePBXProj(path: Path, override: Bool = true) throws {
+    public func writePBXProj(path: AbsolutePath, override: Bool = true) throws {
         try pbxproj.write(path: XcodeProj.pbxprojPath(path), override: override)
     }
 
@@ -114,16 +114,16 @@ extension XcodeProj: Writable {
     ///
     /// - Parameter path: `.xcodeproj` file path
     /// - Returns: shared data path relative to the given path.
-    public static func sharedDataPath(_ path: Path) -> Path {
-        return path + "xcshareddata"
+    public static func sharedDataPath(_ path: AbsolutePath) -> AbsolutePath {
+        return path.appending(component: "xcshareddata")
     }
 
     /// Returns schemes folder path relative to the given path.
     ///
     /// - Parameter path: `.xcodeproj` file path
     /// - Returns: schemes folder path relative to the given path.
-    public static func schemesPath(_ path: Path) -> Path {
-        return XcodeProj.sharedDataPath(path) + "xcschemes"
+    public static func schemesPath(_ path: AbsolutePath) -> AbsolutePath {
+        return XcodeProj.sharedDataPath(path).appending(component: "xcschemes")
     }
 
     /// Returns scheme file path relative to the given path.
@@ -131,8 +131,8 @@ extension XcodeProj: Writable {
     /// - Parameter path: `.xcodeproj` file path
     /// - Parameter schemeName: scheme name
     /// - Returns: scheme file path relative to the given path.
-    public static func schemePath(_ path: Path, schemeName: String) -> Path {
-        return XcodeProj.schemesPath(path) + "\(schemeName).xcscheme"
+    public static func schemePath(_ path: AbsolutePath, schemeName: String) -> AbsolutePath {
+        return XcodeProj.schemesPath(path).appending(component: "\(schemeName).xcscheme")
     }
 
     /// Writes all project schemes to the given path.
@@ -141,7 +141,7 @@ extension XcodeProj: Writable {
     /// - Parameter override: if project should be overridden. Default is true.
     ///   If true will remove all existing schemes before writing.
     ///   If false will throw error if scheme already exists at the given path.
-    public func writeSchemes(path: Path, override: Bool = true) throws {
+    public func writeSchemes(path: AbsolutePath, override: Bool = true) throws {
         guard let sharedData = sharedData else { return }
 
         let schemesPath = XcodeProj.schemesPath(path)
@@ -159,8 +159,8 @@ extension XcodeProj: Writable {
     /// - Parameter path: `.xcodeproj` file path
     /// - Parameter schemeName: scheme name
     /// - Returns: debugger folder path relative to the given path.
-    public static func debuggerPath(_ path: Path) -> Path {
-        return XcodeProj.sharedDataPath(path) + "xcdebugger"
+    public static func debuggerPath(_ path: AbsolutePath) -> AbsolutePath {
+        return XcodeProj.sharedDataPath(path).appending(component: "xcdebugger")
     }
 
     /// Returns breakpoints plist path relative to the given path.
@@ -168,8 +168,8 @@ extension XcodeProj: Writable {
     /// - Parameter path: `.xcodeproj` file path
     /// - Parameter schemeName: scheme name
     /// - Returns: breakpoints plist path relative to the given path.
-    public static func breakPointsPath(_ path: Path) -> Path {
-        return XcodeProj.debuggerPath(path) + "Breakpoints_v2.xcbkptlist"
+    public static func breakPointsPath(_ path: AbsolutePath) -> AbsolutePath {
+        return XcodeProj.debuggerPath(path).appending(component: "Breakpoints_v2.xcbkptlist")
     }
 
     /// Writes all project breakpoints to the given path.
@@ -178,7 +178,7 @@ extension XcodeProj: Writable {
     /// - Parameter override: if project should be overridden. Default is true.
     ///   If true will remove all existing debugger data before writing.
     ///   If false will throw error if breakpoints file exists at the given path.
-    public func writeBreakPoints(path: Path, override: Bool = true) throws {
+    public func writeBreakPoints(path: AbsolutePath, override: Bool = true) throws {
         guard let sharedData = sharedData else { return }
 
         let debuggerPath = XcodeProj.debuggerPath(path)
@@ -208,18 +208,18 @@ extension XcodeProj: Equatable {
 /// - pbxProjNotFound: the .pbxproj file couldn't be found inside the project folder.
 public enum XCodeProjError: Error, CustomStringConvertible {
 
-    case notFound(path: Path)
-    case pbxprojNotFound(path: Path)
-    case xcworkspaceNotFound(path: Path)
+    case notFound(path: AbsolutePath)
+    case pbxprojNotFound(path: AbsolutePath)
+    case xcworkspaceNotFound(path: AbsolutePath)
 
     public var description: String {
         switch self {
         case .notFound(let path):
-            return "The project cannot be found at \(path)"
+            return "The project cannot be found at \(path.asString)"
         case .pbxprojNotFound(let path):
-            return "The project doesn't contain a .pbxproj file at path: \(path)"
+            return "The project doesn't contain a .pbxproj file at path: \(path.asString)"
         case .xcworkspaceNotFound(let path):
-            return "The project doesn't contain a .xcworkspace at path: \(path)"
+            return "The project doesn't contain a .xcworkspace at path: \(path.asString)"
         }
     }
 

--- a/Tests/xcodeprojIntegrationTests/OSSProjectsTests.swift
+++ b/Tests/xcodeprojIntegrationTests/OSSProjectsTests.swift
@@ -1,51 +1,49 @@
 import Foundation
 import XCTest
 import Basic
-import xcodeproj
 
-// TODO
-//final class OSSProjectsTests: XCTestCase {
-//
-//    var tempDirectory: Path!
-//
-//    override func setUp() {
-//        super.setUp()
-//        tempDirectory = (Path(#file) + "../../.." + Path("tmp")).normalize()
-//        try? tempDirectory.delete()
-//        try? tempDirectory.mkpath()
-//    }
-//
-//    override func tearDown() {
-//        super.tearDown()
-//        try? tempDirectory.delete()
-//    }
-//
-//    func test_projects() throws {
-//        try [
-//            (URL(string: "https://github.com/artsy/eigen")!, "Artsy.xcodeproj"),
-//            (URL(string: "https://github.com/rnystrom/GitHawk")!, "Freetime.xcodeproj"),
-//            (URL(string: "https://github.com/insidegui/WWDC")!, "WWDC.xcodeproj"),
-//            (URL(string: "https://github.com/artsy/Emergence")!, "Emergence.xcodeproj")
-//        ].forEach { (project) in
-//            try attemptOpen(gitURL: project.0, projectPath: project.1)
-//        }
-//
-//    }
-//
-//    fileprivate func attemptOpen(gitURL: URL,
-//                                 projectPath: String) throws {
-//        let name = gitURL.lastPathComponent
-//        let clonePath = tempDirectory + Path(name)
-//        print("> Cloning \(gitURL) to run the integration test")
-//        try shellOut(to: "git clone --depth=1 \(gitURL) \(clonePath.string)", at: tempDirectory.string)
-//        let hash = try shellOut(to: "git rev-parse HEAD", at: clonePath.string)
-//        print("> Running tests on commit: \(hash)")
-//        let projectFullPath = clonePath + Path(projectPath)
-//        let project = try XcodeProj(path: projectFullPath)
-//        print("> Project \(projectPath) can be opened ✅")
-//        try project.write(path: projectFullPath)
-//        let diff = try shellOut(to: "git diff", at: clonePath.string)
-//        XCTAssertTrue(diff == "", "Writing project without changes should not result in changes")
-//    }
-//
-//}
+@testable import xcodeproj
+
+final class OSSProjectsTests: XCTestCase {
+
+    var tempDirectory: AbsolutePath!
+
+    override func setUp() {
+        super.setUp()
+        tempDirectory = AbsolutePath(#file).appending(RelativePath("../../../tmp"))
+        try? tempDirectory.delete()
+        try? tempDirectory.mkpath()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        try? tempDirectory.delete()
+    }
+
+    func test_projects() throws {
+        try [
+            (URL(string: "https://github.com/rnystrom/GitHawk")!, "Freetime.xcodeproj"),
+            (URL(string: "https://github.com/insidegui/WWDC")!, "WWDC.xcodeproj"),
+            (URL(string: "https://github.com/artsy/Emergence")!, "Emergence.xcodeproj")
+        ].forEach { (project) in
+            try attemptOpen(gitURL: project.0, projectPath: project.1)
+        }
+
+    }
+
+    fileprivate func attemptOpen(gitURL: URL,
+                                 projectPath: String) throws {
+        let name = gitURL.lastPathComponent
+        let clonePath = tempDirectory.appending(RelativePath(name))
+        print("> Cloning \(gitURL) to run the integration test")
+        try Process.checkNonZeroExit(args: "git", "clone", "--depth=1", gitURL.absoluteString, clonePath.asString)
+        let hash = try Process.popen(args:  "cd", clonePath.asString, "&&", "git", "rev-parse", "HEAD").utf8Output()
+        print("> Running tests on commit: \(hash)")
+        let projectFullPath = clonePath.appending(RelativePath(projectPath))
+        let project = try XcodeProj(path: projectFullPath)
+        print("> Project \(projectPath) can be opened ✅")
+        try project.write(path: projectFullPath)
+        let diff = try Process.popen(args: "cd", clonePath.asString, "&&", "git", "diff").utf8Output()
+        XCTAssertTrue(diff == "", "Writing project without changes should not result in changes")
+    }
+}

--- a/Tests/xcodeprojIntegrationTests/OSSProjectsTests.swift
+++ b/Tests/xcodeprojIntegrationTests/OSSProjectsTests.swift
@@ -1,51 +1,51 @@
 import Foundation
 import XCTest
 import Basic
-import ShellOut
 import xcodeproj
 
-final class OSSProjectsTests: XCTestCase {
-    
-    var tempDirectory: Path!
-    
-    override func setUp() {
-        super.setUp()
-        tempDirectory = (Path(#file) + "../../.." + Path("tmp")).normalize()
-        try? tempDirectory.delete()
-        try? tempDirectory.mkpath()
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-        try? tempDirectory.delete()
-    }
-    
-    func test_projects() throws {
-        try [
-            (URL(string: "https://github.com/artsy/eigen")!, "Artsy.xcodeproj"),
-            (URL(string: "https://github.com/rnystrom/GitHawk")!, "Freetime.xcodeproj"),
-            (URL(string: "https://github.com/insidegui/WWDC")!, "WWDC.xcodeproj"),
-            (URL(string: "https://github.com/artsy/Emergence")!, "Emergence.xcodeproj")
-        ].forEach { (project) in
-            try attemptOpen(gitURL: project.0, projectPath: project.1)
-        }
-        
-    }
-    
-    fileprivate func attemptOpen(gitURL: URL,
-                                 projectPath: String) throws {
-        let name = gitURL.lastPathComponent
-        let clonePath = tempDirectory + Path(name)
-        print("> Cloning \(gitURL) to run the integration test")
-        try shellOut(to: "git clone --depth=1 \(gitURL) \(clonePath.string)", at: tempDirectory.string)
-        let hash = try shellOut(to: "git rev-parse HEAD", at: clonePath.string)
-        print("> Running tests on commit: \(hash)")
-        let projectFullPath = clonePath + Path(projectPath)
-        let project = try XcodeProj(path: projectFullPath)
-        print("> Project \(projectPath) can be opened ✅")
-        try project.write(path: projectFullPath)
-        let diff = try shellOut(to: "git diff", at: clonePath.string)
-        XCTAssertTrue(diff == "", "Writing project without changes should not result in changes")
-    }
-    
-}
+// TODO
+//final class OSSProjectsTests: XCTestCase {
+//
+//    var tempDirectory: Path!
+//
+//    override func setUp() {
+//        super.setUp()
+//        tempDirectory = (Path(#file) + "../../.." + Path("tmp")).normalize()
+//        try? tempDirectory.delete()
+//        try? tempDirectory.mkpath()
+//    }
+//
+//    override func tearDown() {
+//        super.tearDown()
+//        try? tempDirectory.delete()
+//    }
+//
+//    func test_projects() throws {
+//        try [
+//            (URL(string: "https://github.com/artsy/eigen")!, "Artsy.xcodeproj"),
+//            (URL(string: "https://github.com/rnystrom/GitHawk")!, "Freetime.xcodeproj"),
+//            (URL(string: "https://github.com/insidegui/WWDC")!, "WWDC.xcodeproj"),
+//            (URL(string: "https://github.com/artsy/Emergence")!, "Emergence.xcodeproj")
+//        ].forEach { (project) in
+//            try attemptOpen(gitURL: project.0, projectPath: project.1)
+//        }
+//
+//    }
+//
+//    fileprivate func attemptOpen(gitURL: URL,
+//                                 projectPath: String) throws {
+//        let name = gitURL.lastPathComponent
+//        let clonePath = tempDirectory + Path(name)
+//        print("> Cloning \(gitURL) to run the integration test")
+//        try shellOut(to: "git clone --depth=1 \(gitURL) \(clonePath.string)", at: tempDirectory.string)
+//        let hash = try shellOut(to: "git rev-parse HEAD", at: clonePath.string)
+//        print("> Running tests on commit: \(hash)")
+//        let projectFullPath = clonePath + Path(projectPath)
+//        let project = try XcodeProj(path: projectFullPath)
+//        print("> Project \(projectPath) can be opened ✅")
+//        try project.write(path: projectFullPath)
+//        let diff = try shellOut(to: "git diff", at: clonePath.string)
+//        XCTAssertTrue(diff == "", "Writing project without changes should not result in changes")
+//    }
+//
+//}

--- a/Tests/xcodeprojIntegrationTests/OSSProjectsTests.swift
+++ b/Tests/xcodeprojIntegrationTests/OSSProjectsTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import PathKit
+import Basic
 import ShellOut
 import xcodeproj
 

--- a/Tests/xcodeprojTests/Dictionary+ExtrasSpec.swift
+++ b/Tests/xcodeprojTests/Dictionary+ExtrasSpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 import XCTest
 import xcodeproj
 

--- a/Tests/xcodeprojTests/Dictionary+ExtrasSpec.swift
+++ b/Tests/xcodeprojTests/Dictionary+ExtrasSpec.swift
@@ -5,11 +5,11 @@ import xcodeproj
 
 class DictionaryExtrasSpec: XCTestCase {
 
-    var fixtures: Path!
+    var fixtures: AbsolutePath!
 
     override func setUp() {
         super.setUp()
-        fixtures = Path(#file).parent().parent().parent() + Path("Fixtures")
+        fixtures = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory.appending(component: "Fixtures")
     }
 
     func test_loadPlist_returnsANilValue_whenTheFileDoesntExist() {
@@ -17,8 +17,8 @@ class DictionaryExtrasSpec: XCTestCase {
     }
 
     func test_loadPlist_returnsTheDictionary_whenTheFileDoesExist() {
-        let iosProject = fixtures + Path("iOS/Project.xcodeproj/project.pbxproj")
-        XCTAssertNotNil(loadPlist(path: iosProject.absolute().string))
+        let iosProject = fixtures.appending(RelativePath("iOS/Project.xcodeproj/project.pbxproj"))
+        XCTAssertNotNil(loadPlist(path: iosProject.asString))
     }
 }
 

--- a/Tests/xcodeprojTests/Fixtures.swift
+++ b/Tests/xcodeprojTests/Fixtures.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 import xcodeproj
 
 func fixturesPath() -> Path {

--- a/Tests/xcodeprojTests/Fixtures.swift
+++ b/Tests/xcodeprojTests/Fixtures.swift
@@ -2,11 +2,11 @@ import Foundation
 import Basic
 import xcodeproj
 
-func fixturesPath() -> Path {
-    return Path(#file).parent().parent().parent() + Path("Fixtures")
+func fixturesPath() -> AbsolutePath {
+    return AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory.appending(component: "Fixtures")
 }
 
-func iosProjectDictionary() -> (Path, Dictionary<String, Any>) {
-    let iosProject = fixturesPath() + Path("iOS/Project.xcodeproj/project.pbxproj")
-    return (iosProject, loadPlist(path: iosProject.absolute().string)!)
+func iosProjectDictionary() -> (AbsolutePath, Dictionary<String, Any>) {
+    let iosProject = fixturesPath().appending(RelativePath("iOS/Project.xcodeproj/project.pbxproj"))
+    return (iosProject, loadPlist(path: iosProject.asString)!)
 }

--- a/Tests/xcodeprojTests/PBXProjSpec.swift
+++ b/Tests/xcodeprojTests/PBXProjSpec.swift
@@ -1,7 +1,8 @@
 import Foundation
 import XCTest
 import Basic
-import xcodeproj
+
+@testable import xcodeproj
 
 extension PBXProj {
 
@@ -81,8 +82,8 @@ final class PBXProjIntegrationSpec: XCTestCase {
                   modify: { $0 })
     }
 
-    private func fixturePath() -> Path {
-        let path = fixturesPath() + Path("iOS/Project.xcodeproj/project.pbxproj")
+    private func fixturePath() -> AbsolutePath {
+        let path = fixturesPath().appending(RelativePath("iOS/Project.xcodeproj/project.pbxproj"))
         return path
     }
 

--- a/Tests/xcodeprojTests/PBXProjSpec.swift
+++ b/Tests/xcodeprojTests/PBXProjSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import PathKit
+import Basic
 import xcodeproj
 
 extension PBXProj {

--- a/Tests/xcodeprojTests/PBXProjWriterSpec.swift
+++ b/Tests/xcodeprojTests/PBXProjWriterSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import PathKit
+import Basic
 
 @testable import xcodeproj
 

--- a/Tests/xcodeprojTests/XCBreakpointListSpec.swift
+++ b/Tests/xcodeprojTests/XCBreakpointListSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import PathKit
+import Basic
 import xcodeproj
 
 final class XCBreakpointListIntegrationSpec: XCTestCase {

--- a/Tests/xcodeprojTests/XCBreakpointListSpec.swift
+++ b/Tests/xcodeprojTests/XCBreakpointListSpec.swift
@@ -107,8 +107,8 @@ final class XCBreakpointListIntegrationSpec: XCTestCase {
         XCTAssertNotNil(ideTestFailureAppleScriptAction.actionContent)
     }
 
-    private func fixturePath() -> Path {
-        return fixturesPath() + Path("iOS/Project.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist")
+    private func fixturePath() -> AbsolutePath {
+        return fixturesPath().appending(RelativePath("iOS/Project.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist"))
     }
 
 }

--- a/Tests/xcodeprojTests/XCConfigSpec.swift
+++ b/Tests/xcodeprojTests/XCConfigSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 @testable import xcodeproj
-import PathKit
+import Basic
 
 final class XCConfigSpec: XCTestCase {
 

--- a/Tests/xcodeprojTests/XCConfigSpec.swift
+++ b/Tests/xcodeprojTests/XCConfigSpec.swift
@@ -10,8 +10,8 @@ final class XCConfigSpec: XCTestCase {
     func test_init_initializesTheConfigWithTheRightAttributes() {
         let configA = XCConfig(includes: [])
         let configB = XCConfig(includes: [])
-        let config = XCConfig(includes: [(Path("testA"), configA),
-                                         (Path("testB"), configB)],
+        let config = XCConfig(includes: [(RelativePath("testA"), configA),
+                                         (RelativePath("testB"), configB)],
                               buildSettings: ["a": "b"])
         XCTAssertEqual(config.buildSettings as! [String: String], ["a": "b"])
         XCTAssertEqual(config.includes[0].config, configA)
@@ -21,8 +21,8 @@ final class XCConfigSpec: XCTestCase {
     func test_flattened_flattensTheConfigCorrectly() {
         let configA = XCConfig(includes: [], buildSettings: ["a": "1"])
         let configB = XCConfig(includes: [], buildSettings: ["a": "2"])
-        let config = XCConfig(includes: [(Path("testA"), configA),
-                                         (Path("testB"), configB)],
+        let config = XCConfig(includes: [(RelativePath("testA"), configA),
+                                         (RelativePath("testB"), configB)],
                               buildSettings: ["b": "3"])
         let buildSettings = config.flattenedBuildSettings()
         XCTAssertEqual(buildSettings["a"] as? String, "2")
@@ -69,8 +69,8 @@ final class XCConfigSpec: XCTestCase {
     }
 
     func test_errorDescription_returnsTheCorrectDescription_whenNotFound() {
-        let error = XCConfigError.notFound(path: Path("test"))
-        XCTAssertEqual(error.description, ".xcconfig file not found at test")
+        let error = XCConfigError.notFound(path: AbsolutePath("/test"))
+        XCTAssertEqual(error.description, ".xcconfig file not found at /test")
     }
 
 }
@@ -91,12 +91,12 @@ final class XCConfigIntegrationSpec: XCTestCase {
                   modify: { $0 })
     }
 
-    private func childrenPath() -> Path {
-        return fixturesPath() + Path("XCConfigs/Children.xcconfig")
+    private func childrenPath() -> AbsolutePath {
+        return fixturesPath().appending(RelativePath("XCConfigs/Children.xcconfig"))
     }
 
-    private func parentPath() -> Path {
-        return fixturesPath() + Path("XCConfigs/Parent.xcconfig")
+    private func parentPath() -> AbsolutePath {
+        return fixturesPath().appending(RelativePath("XCConfigs/Parent.xcconfig"))
     }
 
     private func assert(config: XCConfig) {

--- a/Tests/xcodeprojTests/XCSchemeSpec.swift
+++ b/Tests/xcodeprojTests/XCSchemeSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import PathKit
+import Basic
 import xcodeproj
 
 final class XCSchemeIntegrationSpec: XCTestCase {

--- a/Tests/xcodeprojTests/XCSchemeSpec.swift
+++ b/Tests/xcodeprojTests/XCSchemeSpec.swift
@@ -248,14 +248,14 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertNil(scheme.archiveAction?.customArchiveName)
     }
 
-    private var iosSchemePath: Path {
-        return fixturesPath() + Path("iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme")
+    private var iosSchemePath: AbsolutePath {
+        return fixturesPath().appending(RelativePath("iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme"))
     }
 
-    private var minimalSchemePath: Path {
+    private var minimalSchemePath: AbsolutePath {
         // Not strictly minimal in the sense that it specifies the least amount of information to be valid,
         // but minimal in the sense it doesn't have most of the standard elements and attributes.
-        return fixturesPath() + Path("Schemes/MinimalInformation.xcscheme")
+        return fixturesPath().appending(RelativePath("Schemes/MinimalInformation.xcscheme"))
     }
 
 }

--- a/Tests/xcodeprojTests/XCWorkspaceDataSpec.swift
+++ b/Tests/xcodeprojTests/XCWorkspaceDataSpec.swift
@@ -38,7 +38,7 @@ final class XCWorkspaceDataIntegrationSpec: XCTestCase {
 
     func test_init_throwsIfThePathIsWrong() {
         do {
-            _ = try XCWorkspace(path: Path("test"))
+            _ = try XCWorkspace(path: AbsolutePath("/test"))
             XCTAssertTrue(false, "Expected to throw an error but it didn't")
         } catch {}
     }
@@ -115,12 +115,12 @@ final class XCWorkspaceDataIntegrationSpec: XCTestCase {
 
     // MARK: - Private
 
-    private func fixturePath() -> Path {
-        return fixturesPath() + Path("iOS/Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata")
+    private func fixturePath() -> AbsolutePath {
+        return fixturesPath().appending(RelativePath("iOS/Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata"))
     }
 
     private func fixtureWorkspace() throws -> XCWorkspace {
-        let path = fixturesPath() + Path("Workspace.xcworkspace")
+        let path = fixturesPath().appending(RelativePath("Workspace.xcworkspace"))
         return try XCWorkspace(path: path)
     }
 

--- a/Tests/xcodeprojTests/XCWorkspaceDataSpec.swift
+++ b/Tests/xcodeprojTests/XCWorkspaceDataSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import PathKit
+import Basic
 import xcodeproj
 
 final class XCWorkspaceDataSpec: XCTestCase {

--- a/Tests/xcodeprojTests/XCWorkspaceSpec.swift
+++ b/Tests/xcodeprojTests/XCWorkspaceSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import PathKit
+import Basic
 import xcodeproj
 
 final class XCWorkspaceIntegrationSpec: XCTestCase {

--- a/Tests/xcodeprojTests/XCWorkspaceSpec.swift
+++ b/Tests/xcodeprojTests/XCWorkspaceSpec.swift
@@ -6,14 +6,14 @@ import xcodeproj
 final class XCWorkspaceIntegrationSpec: XCTestCase {
 
     func test_initTheWorkspaceWithTheRightPropeties() {
-        let path = fixturesPath() + Path("iOS/Project.xcodeproj/project.xcworkspace")
+        let path = fixturesPath().appending(RelativePath("iOS/Project.xcodeproj/project.xcworkspace"))
         let got = try? XCWorkspace(path: path)
         XCTAssertNotNil(got)
     }
 
     func test_initFailsIfThePathIsWrong() {
         do {
-            _ = try XCWorkspace(path: Path("test"))
+            _ = try XCWorkspace(path: AbsolutePath("/test"))
             XCTAssertTrue(false, "Expected to throw an error but it didn't")
         } catch {}
     }

--- a/Tests/xcodeprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcodeprojTests/XcodeProjIntegrationSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import PathKit
+import Basic
 import xcodeproj
 
 final class XcodeProjIntegrationSpec: XCTestCase {

--- a/Tests/xcodeprojTests/testWrite.swift
+++ b/Tests/xcodeprojTests/testWrite.swift
@@ -1,5 +1,5 @@
 import Foundation
-import PathKit
+import Basic
 import XCTest
 import xcodeproj
 

--- a/Tests/xcodeprojTests/testWrite.swift
+++ b/Tests/xcodeprojTests/testWrite.swift
@@ -1,19 +1,20 @@
 import Foundation
 import Basic
 import XCTest
-import xcodeproj
 
-func testWrite<T: Writable & Equatable>(from path: Path,
-               initModel: (Path) -> T?,
+@testable import xcodeproj
+
+func testWrite<T: Writable & Equatable>(from path: AbsolutePath,
+               initModel: (AbsolutePath) -> T?,
                modify: (T) -> (T)) {
     testWrite(from: path, initModel: initModel, modify: modify, assertion: { XCTAssertEqual($0, $1) })
 }
 
-func testWrite<T: Writable>(from path: Path,
-                       initModel: (Path) -> T?,
+func testWrite<T: Writable>(from path: AbsolutePath,
+                       initModel: (AbsolutePath) -> T?,
                        modify: (T) -> (T),
                        assertion: (_ before: T, _ after: T) -> ()) {
-    let copyPath = path.parent() + "copy.\(path.extension!)"
+    let copyPath = path.parentDirectory.appending(component: "copy.\(path.extension!)")
     try? copyPath.delete()
     try? path.copy(copyPath)
     let got = initModel(copyPath)


### PR DESCRIPTION
### Short description 📝
Use Swift Package Manager utils instead of `PathKit` and `ShellOut`.

### Implementation 👩‍💻👨‍💻
- [x] Remove `PathKit` and `ShellOut`.
- [x] Refactor `PathKit` usages.
- [x] Refactor `ShellOut` usages.